### PR TITLE
Fix having several "hand written" properties

### DIFF
--- a/core/class.rs
+++ b/core/class.rs
@@ -371,14 +371,17 @@ impl ClassDefinition {
                 = #glib::once_cell::sync::OnceCell::new();
         })
     }
-    fn adjust_property_index(&self) -> Option<TokenStream> {
-        self.inner
-            .has_method(TypeMode::Subclass, "properties")
-            .then(|| {
-                quote_spanned! { Span::mixed_site() =>
-                    let id = id - self::_GENERATED_PROPERTIES_BASE_INDEX.get().unwrap();
-                }
-            })
+    fn adjust_property_index(&self) -> TokenStream {
+        if self.inner.has_method(TypeMode::Subclass, "properties") {
+            quote_spanned! { Span::mixed_site() =>
+                let generated_prop_id = id as i64 - *self::_GENERATED_PROPERTIES_BASE_INDEX.get().unwrap() as i64;
+            }
+        } else {
+            quote_spanned! { Span::mixed_site() =>
+                let generated_prop_id = id as i64;
+            }
+
+        }
     }
     #[inline]
     fn unimplemented_property(glib: &syn::Path) -> TokenStream {

--- a/core/property.rs
+++ b/core/property.rs
@@ -877,8 +877,8 @@ impl Property {
     }
     #[inline]
     fn pspec_cmp(&self, index: usize) -> TokenStream {
-        let index = index + 1;
-        quote_spanned! { Span::mixed_site() => id == #index }
+        let index = (index + 1) as i64;
+        quote_spanned! { Span::mixed_site() => generated_prop_id == #index}
     }
     pub fn custom_method_path(&self, set: bool) -> Option<Cow<syn::Ident>> {
         let perm = match set {

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -60,20 +60,32 @@ mod obj_inner {
         #[property(get, set)]
         my_prop: std::cell::Cell<u64>,
         my_uint: std::cell::Cell<u32>,
+        your_uint: std::cell::Cell<u32>,
     }
     impl ObjInner {
         #[signal]
         fn abc(&self) {}
         fn properties() -> Vec<glib::ParamSpec> {
-            vec![glib::ParamSpecUInt::new(
-                "my-uint",
-                "my-uint",
-                "my-uint",
-                0,
-                u32::MAX,
-                0,
-                glib::ParamFlags::READWRITE,
-            )]
+            vec![
+                glib::ParamSpecUInt::new(
+                    "my-uint",
+                    "my-uint",
+                    "my-uint",
+                    0,
+                    u32::MAX,
+                    0,
+                    glib::ParamFlags::READWRITE,
+                ),
+                glib::ParamSpecUInt::new(
+                    "your-uint",
+                    "your-uint",
+                    "your-uint",
+                    0,
+                    u32::MAX,
+                    0,
+                    glib::ParamFlags::READWRITE,
+                ),
+            ]
         }
 
         fn set_property(
@@ -85,6 +97,7 @@ mod obj_inner {
         ) {
             match pspec.name() {
                 "my-uint" => self.my_uint.set(value.get().unwrap()),
+                "your-uint" => self.your_uint.set(value.get().unwrap()),
                 _ => unimplemented!(),
             }
         }
@@ -97,6 +110,7 @@ mod obj_inner {
         ) -> glib::Value {
             match pspec.name() {
                 "my-uint" => glib::ToValue::to_value(&self.my_uint.get()),
+                "your-uint" => glib::ToValue::to_value(&self.your_uint.get()),
                 _ => unimplemented!(),
             }
         }
@@ -112,13 +126,19 @@ fn object_inner_methods() {
     use glib::prelude::*;
 
     let obj = glib::Object::new::<ObjInner>(&[]).unwrap();
-    assert_eq!(obj.list_properties().len(), 2);
+    assert_eq!(obj.list_properties().len(), 3);
     obj.emit_abc();
     obj.emit_by_name::<()>("xyz", &[]);
     obj.set_my_prop(22);
+
+    assert_eq!(obj.property::<u32>("my-uint"), 0);
     obj.set_property("my-uint", 500u32);
     assert_eq!(obj.my_prop(), 22);
     assert_eq!(obj.property::<u32>("my-uint"), 500);
+
+    assert_eq!(obj.property::<u32>("your-uint"), 0);
+    obj.set_property("your-uint", 500u32);
+    assert_eq!(obj.property::<u32>("your-uint"), 500);
 }
 
 #[gobject::class(final, sync)]


### PR DESCRIPTION
We were overflowing when calculating the "generated_prop_id", let it be
negative when setting/getting a manually added property:

```
thread 'object_inner_methods' panicked at 'attempt to subtract with overflow', /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/ops/arith.rs:240:1
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/panicking.rs:48:5
   3: <usize as core::ops::arith::Sub>::sub
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/ops/arith.rs:233:45
   4: <usize as core::ops::arith::Sub<&usize>>::sub
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/internal_macros.rs:61:17
   5: <object::obj_inner::ObjInner as glib::subclass::object::ObjectImpl>::property
             at ./tests/object.rs:56:1
   6: glib::subclass::object::property
             at /var/home/thiblahute/devel/misc/gtk-rs-core/glib/src/subclass/object.rs:80:13
   7: g_object_get_property
   8: <T as glib::object::ObjectExt>::try_property_value
             at /var/home/thiblahute/devel/misc/gtk-rs-core/glib/src/object.rs:2515:13
   9: <T as glib::object::ObjectExt>::try_property
             at /var/home/thiblahute/devel/misc/gtk-rs-core/glib/src/object.rs:2485:20
  10: <T as glib::object::ObjectExt>::property
             at /var/home/thiblahute/devel/misc/gtk-rs-core/glib/src/object.rs:2493:9
  11: object::object_inner_methods
             at ./tests/object.rs:134:16
  12: object::object_inner_methods::{{closure}}
             at ./tests/object.rs:125:1
  13: core::ops::function::FnOnce::call_once
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/ops/function.rs:248:5
  14: core::ops::function::FnOnce::call_once
             at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```